### PR TITLE
Change VARCHAR to TEXT

### DIFF
--- a/db_maintenance.php
+++ b/db_maintenance.php
@@ -18,7 +18,7 @@ function db_install() {
     global $conn, $curr_version;
     $query = 'CREATE TABLE quotes (
             id MEDIUMINT AUTO_INCREMENT,
-            quote VARCHAR(32768),
+            quote TEXT(32768),
             postdate DATETIME NOT NULL,
             PRIMARY KEY (id)
             )';


### PR DESCRIPTION
MySQL seems to throw an error because "32768" exceedes the max value so `VARCHAR` should be changed to `TEXT`.